### PR TITLE
Add TeleGet - High-speed Telegram file downloader SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1178,3 +1178,5 @@ A curated list of awesome Python frameworks, libraries and software.
 * [orchest/orchest](https://github.com/orchest/orchest) - Build data pipelines, the easy way 🛠️
 * [SecureAuthCorp/impacket](https://github.com/SecureAuthCorp/impacket) - Impacket is a collection of Python classes for working with network protocols.
 * [py-pdf/PyPDF2](https://github.com/py-pdf/PyPDF2) - A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files
+
+- [TeleGet](https://github.com/xwc9527/TeleGet) - High-speed Telegram file downloader SDK with multi-connection parallel downloading.


### PR DESCRIPTION
## Add TeleGet

[TeleGet](https://github.com/xwc9527/TeleGet) is a Python SDK for high-speed Telegram file downloading.

**Features:**
- Multi-connection parallel downloading (WorkerPool + ClientPool)
- Cross-DC download support with automatic DC connection pool
- Sparse file pre-allocation (Windows NTFS)
- Checkpoint-based resume
- fsync throttling for HDD optimization

**Install:** `pip install teleget9527`

**PyPI:** https://pypi.org/project/teleget9527/