### PR TITLE
Add net-benchmark to awesome-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,3 +1198,4 @@ A curated list of awesome Python frameworks, libraries and software.
 * [orchest/orchest](https://github.com/orchest/orchest) - Build data pipelines, the easy way 🛠️
 * [SecureAuthCorp/impacket](https://github.com/SecureAuthCorp/impacket) - Impacket is a collection of Python classes for working with network protocols.
 * [py-pdf/PyPDF2](https://github.com/py-pdf/PyPDF2) - A pure-python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files
+* [net-benchmark/net-benchmark](https://github.com/net-benchmark/net-benchmark) - DNS/HTTP/SSL benchmarking suite with DNSSEC, DoH/DoT, high-concurrency tests, and CSV/Excel/PDF/JSON exports


### PR DESCRIPTION
Add net-benchmark to the awesome-python list.

net-benchmark is a Python-based network benchmarking suite for DNS, HTTP, and
SSL/TLS. It includes DNSSEC validation, DoH/DoT support, high-concurrency
testing, and enterprise-grade reporting with CSV, Excel, PDF, and JSON exports.

Project: https://github.com/net-benchmark/net-benchmark
